### PR TITLE
Added support for the PlantUML toolkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         sudo apt-get --quiet --yes install graphviz
 
         sudo apt-get --quiet --yes install plantuml
-        mv /usr/share/plantuml/plantuml.jar .
+        sudo mv /usr/share/plantuml/plantuml.jar .
         java -jar plantuml.jar -h
 
     - name: Install Graphviz [Windows]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,10 @@ jobs:
         sudo apt-get --quiet --yes install octave
         sudo apt-get --quiet --yes install gnuplot
         sudo apt-get --quiet --yes install graphviz
+
         sudo apt-get --quiet --yes install plantuml
+        mv /usr/share/plantuml/plantuml.jar .
+        java -jar plantuml.jar -h
 
     - name: Install Graphviz [Windows]
       if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [master]
   pull_request:
 
 jobs:
@@ -63,12 +62,13 @@ jobs:
       run: |
         Rscript -e "install.packages('ggplot2', repos='http://cran.rstudio.com/')"
 
-    - name: Install Octave, Gnuplot, Graphviz [Linux]
+    - name: Install Octave, Gnuplot, Graphviz, and PlantUML [Linux]
       if: runner.os == 'Linux'
       run: |
         sudo apt-get --quiet --yes install octave
         sudo apt-get --quiet --yes install gnuplot
         sudo apt-get --quiet --yes install graphviz
+        sudo apt-get --quiet --yes install plantuml
 
     - name: Install Graphviz [Windows]
       if: runner.os == 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 pandoc-plot uses [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+Release 1.1.0
+-------------
+
+* Added the [PlantUML](https://plantuml.com) toolkit (#18). Diagrams can be generated like so:
+
+  ````markdown
+
+  ```{.plantuml}
+  @startuml
+  Bob->Alice : hello
+  @enduml
+  ```
+
+  ````
+* Changed versioning scheme to match more common Major.Minor.Bugfix.
+
 Release 1.0.2.1
 ---------------
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ breaking changes in pandoc’s API.*
   - `gnuplot`: plots using [gnuplot](http://www.gnuplot.info/);
   - `graphviz`: graphs using [Graphviz](http://graphviz.org/);
   - `bokeh`: plots using the [Bokeh](https://bokeh.org/) visualization library;
-  - `plotsjl`: plots using the [Julia `Plots.jl`](https://docs.juliaplots.org/latest/) package.
+  - `plotsjl`: plots using the [Julia `Plots.jl`](https://docs.juliaplots.org/latest/) package;
   - `plantuml`: diagrams using the [`PlantUML`](https://plantuml.com/) software suite.
 
 To know which toolkits are useable on *your machine* (and which ones are

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ breaking changes in pandoc’s API.*
   - `graphviz`: graphs using [Graphviz](http://graphviz.org/);
   - `bokeh`: plots using the [Bokeh](https://bokeh.org/) visualization library;
   - `plotsjl`: plots using the [Julia `Plots.jl`](https://docs.juliaplots.org/latest/) package.
+  - `plantuml`: diagrams using the [`PlantUML`](https://plantuml.com/) software suite.
 
 To know which toolkits are useable on *your machine* (and which ones are
 not available), you can check with the `toolkits` command:

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,8 @@ plot-configuration: plot-config.yml
   - `gnuplot`: plots using [gnuplot](http://www.gnuplot.info/);
   - `graphviz`: graphs using [Graphviz](http://graphviz.org/);
   - `bokeh`: plots using the [Bokeh](https://bokeh.org/) visualization library;
-  - `plotsjl`: plots using the [Julia `Plots.jl`](http://docs.juliaplots.org/latest/) package.
+  - `plotsjl`: plots using the [Julia `Plots.jl`](http://docs.juliaplots.org/latest/) package;
+  - `plantuml`: diagrams using [PlantUML](https://plantuml.com).
 
 ## Simple examples
 

--- a/docs/manual-content.md
+++ b/docs/manual-content.md
@@ -202,7 +202,7 @@ There are parameters that affect the figure that will be included in your docume
 
 ````
 
-* `cls` must be one of the following: `matplotlib`, `matlabplot`, `plotly_python`, `plotly_r`, `mathplot`, `octaveplot`, `ggplot2`, `gnuplot`, `graphviz`, `bokeh`, `plotsjl`.
+* `cls` must be one of the following: `matplotlib`, `matlabplot`, `plotly_python`, `plotly_r`, `mathplot`, `octaveplot`, `ggplot2`, `gnuplot`, `graphviz`, `bokeh`, `plotsjl`, `plantuml` (*new in version 1.1.0*).
 
 All following parameters are optional, with their default values controlled by the [configuration](#configuration).
 

--- a/example-config.yml
+++ b/example-config.yml
@@ -129,3 +129,8 @@ plantuml:
   # preamble: plantuml.txt
   executable: java
   command_line_arguments: -jar plantuml.jar
+  # On Linux, it you have `plantuml.jar` as an executable, you can also
+  # use the following configuration instead:
+  # plantuml:
+  #   executable: plantuml
+  #   command_line_arguments:

--- a/example-config.yml
+++ b/example-config.yml
@@ -124,3 +124,8 @@ plotsjl:
   # preamble: plotsjl.jl
   executable: julia
   command_line_arguments:
+
+plantuml:
+  # preamble: plantuml.txt
+  executable: java -jar plantuml.jar
+  command_line_arguments:

--- a/example-config.yml
+++ b/example-config.yml
@@ -127,5 +127,5 @@ plotsjl:
 
 plantuml:
   # preamble: plantuml.txt
-  executable: java -jar plantuml.jar
-  command_line_arguments:
+  executable: java
+  command_line_arguments: -jar plantuml.jar

--- a/pandoc-plot.cabal
+++ b/pandoc-plot.cabal
@@ -1,6 +1,6 @@
 cabal-version:  2.2
 name:           pandoc-plot
-version:        1.1.0.0
+version:        1.1.0
 synopsis:       A Pandoc filter to include figures generated from code blocks using your plotting toolkit of choice.
 description:    A Pandoc filter to include figures generated from code blocks. 
                 Keep the document and code in the same location. Output is 
@@ -14,7 +14,7 @@ maintainer:     Laurent P. René de Cotret
 license:        GPL-2.0-or-later
 license-file:   LICENSE
 build-type:     Simple
-tested-with:    GHC == 8.10.3
+tested-with:    GHC == 8.10.4
 extra-source-files:
     CHANGELOG.md
     LICENSE

--- a/pandoc-plot.cabal
+++ b/pandoc-plot.cabal
@@ -1,6 +1,6 @@
 cabal-version:  2.2
 name:           pandoc-plot
-version:        1.0.3.0
+version:        1.1.0.0
 synopsis:       A Pandoc filter to include figures generated from code blocks using your plotting toolkit of choice.
 description:    A Pandoc filter to include figures generated from code blocks. 
                 Keep the document and code in the same location. Output is 
@@ -78,6 +78,7 @@ library
         Text.Pandoc.Filter.Plot.Renderers.Graphviz
         Text.Pandoc.Filter.Plot.Renderers.Bokeh
         Text.Pandoc.Filter.Plot.Renderers.Plotsjl
+        Text.Pandoc.Filter.Plot.Renderers.PlantUML
         Text.Pandoc.Filter.Plot.Monad
         Text.Pandoc.Filter.Plot.Monad.Logging
         Text.Pandoc.Filter.Plot.Monad.Types

--- a/src/Text/Pandoc/Filter/Plot/Configuration.hs
+++ b/src/Text/Pandoc/Filter/Plot/Configuration.hs
@@ -61,6 +61,7 @@ defaultConfiguration =
       graphvizPreamble = mempty,
       bokehPreamble = mempty,
       plotsjlPreamble = mempty,
+      plantumlPreamble = mempty,
       -- Executables
       matplotlibExe = python,
       matlabExe = "matlab",
@@ -73,6 +74,7 @@ defaultConfiguration =
       graphvizExe = "dot",
       bokehExe = python,
       plotsjlExe = "julia",
+      plantumlExe = "java -jar plantuml.jar",
       -- Command line arguments
       matplotlibCmdArgs = mempty,
       matlabCmdArgs = mempty,
@@ -85,6 +87,7 @@ defaultConfiguration =
       graphvizCmdArgs = mempty,
       bokehCmdArgs = mempty,
       plotsjlCmdArgs = mempty,
+      plantumlCmdArgs = mempty,
       -- Extras
       matplotlibTightBBox = False,
       matplotlibTransparent = False
@@ -142,7 +145,8 @@ data ConfigPrecursor = ConfigPrecursor
     _gnuplotPrec :: !GNUPlotPrecursor,
     _graphvizPrec :: !GraphvizPrecursor,
     _bokehPrec :: !BokehPrecursor,
-    _plotsjlPrec :: !PlotsjlPrecursor
+    _plotsjlPrec :: !PlotsjlPrecursor,
+    _plantumlPrec :: !PlantUMLPrecursor
   }
 
 defaultConfigPrecursor :: ConfigPrecursor
@@ -167,7 +171,8 @@ defaultConfigPrecursor =
       _gnuplotPrec = GNUPlotPrecursor Nothing (gnuplotExe defaultConfiguration) (gnuplotCmdArgs defaultConfiguration),
       _graphvizPrec = GraphvizPrecursor Nothing (graphvizExe defaultConfiguration) (graphvizCmdArgs defaultConfiguration),
       _bokehPrec = BokehPrecursor Nothing (bokehExe defaultConfiguration) (bokehCmdArgs defaultConfiguration),
-      _plotsjlPrec = PlotsjlPrecursor Nothing (plotsjlExe defaultConfiguration) (plotsjlCmdArgs defaultConfiguration)
+      _plotsjlPrec = PlotsjlPrecursor Nothing (plotsjlExe defaultConfiguration) (plotsjlCmdArgs defaultConfiguration),
+      _plantumlPrec = PlantUMLPrecursor Nothing (plantumlExe defaultConfiguration) (plantumlCmdArgs defaultConfiguration)
     }
 
 data LoggingPrecursor = LoggingPrecursor
@@ -203,6 +208,8 @@ data GraphvizPrecursor = GraphvizPrecursor {_graphvizPreamble :: !(Maybe FilePat
 data BokehPrecursor = BokehPrecursor {_bokehPreamble :: !(Maybe FilePath), _bokehExe :: !FilePath, _bokehCmdArgs :: !Text}
 
 data PlotsjlPrecursor = PlotsjlPrecursor {_plotsjlPreamble :: !(Maybe FilePath), _plotsjlExe :: !FilePath, _plotsjlCmdArgs :: !Text}
+
+data PlantUMLPrecursor = PlantUMLPrecursor {_plantumlPreamble :: !(Maybe FilePath), _plantumlExe :: !FilePath, _plantumlCmdArgs :: !Text}
 
 instance FromJSON LoggingPrecursor where
   parseJSON (Object v) =
@@ -260,6 +267,10 @@ instance FromJSON PlotsjlPrecursor where
   parseJSON (Object v) = PlotsjlPrecursor <$> v .:? (tshow PreambleK) <*> v .:? (tshow ExecutableK) .!= (plotsjlExe defaultConfiguration) <*> v .:? (tshow CommandLineArgsK) .!= (plotsjlCmdArgs defaultConfiguration)
   parseJSON _ = fail $ mconcat ["Could not parse ", show Plotsjl, " configuration."]
 
+instance FromJSON PlantUMLPrecursor where
+  parseJSON (Object v) = PlantUMLPrecursor <$> v .:? (tshow PreambleK) <*> v .:? (tshow ExecutableK) .!= (plantumlExe defaultConfiguration) <*> v .:? (tshow CommandLineArgsK) .!= (plantumlCmdArgs defaultConfiguration)
+  parseJSON _ = fail $ mconcat ["Could not parse ", show PlantUML, " configuration."]
+
 instance FromJSON ConfigPrecursor where
   parseJSON (Null) = return defaultConfigPrecursor -- In case of empty file
   parseJSON (Object v) = do
@@ -284,6 +295,7 @@ instance FromJSON ConfigPrecursor where
     _graphvizPrec <- v .:? (cls Graphviz) .!= _graphvizPrec defaultConfigPrecursor
     _bokehPrec <- v .:? (cls Bokeh) .!= _bokehPrec defaultConfigPrecursor
     _plotsjlPrec <- v .:? (cls Plotsjl) .!= _plotsjlPrec defaultConfigPrecursor
+    _plantumlPrec <- v .:? (cls PlantUML ) .!= _plantumlPrec defaultConfigPrecursor
 
     return $ ConfigPrecursor {..}
   parseJSON _ = fail "Could not parse configuration."
@@ -316,6 +328,7 @@ renderConfig ConfigPrecursor {..} = do
       graphvizExe = _graphvizExe _graphvizPrec
       bokehExe = _bokehExe _bokehPrec
       plotsjlExe = _plotsjlExe _plotsjlPrec
+      plantumlExe = _plantumlExe _plantumlPrec
 
       matplotlibCmdArgs = _matplotlibCmdArgs _matplotlibPrec
       matlabCmdArgs = _matlabCmdArgs _matlabPrec
@@ -328,6 +341,7 @@ renderConfig ConfigPrecursor {..} = do
       graphvizCmdArgs = _graphvizCmdArgs _graphvizPrec
       bokehCmdArgs = _bokehCmdArgs _bokehPrec
       plotsjlCmdArgs = _plotsjlCmdArgs _plotsjlPrec
+      plantumlCmdArgs = _plantumlCmdArgs _plantumlPrec
 
   matplotlibPreamble <- readPreamble (_matplotlibPreamble _matplotlibPrec)
   matlabPreamble <- readPreamble (_matlabPreamble _matlabPrec)
@@ -340,6 +354,7 @@ renderConfig ConfigPrecursor {..} = do
   graphvizPreamble <- readPreamble (_graphvizPreamble _graphvizPrec)
   bokehPreamble <- readPreamble (_bokehPreamble _bokehPrec)
   plotsjlPreamble <- readPreamble (_plotsjlPreamble _plotsjlPrec)
+  plantumlPreamble <- readPreamble (_plantumlPreamble _plantumlPrec)
 
   return Configuration {..}
   where

--- a/src/Text/Pandoc/Filter/Plot/Configuration.hs
+++ b/src/Text/Pandoc/Filter/Plot/Configuration.hs
@@ -74,7 +74,7 @@ defaultConfiguration =
       graphvizExe = "dot",
       bokehExe = python,
       plotsjlExe = "julia",
-      plantumlExe = "java -jar plantuml.jar",
+      plantumlExe = "java",
       -- Command line arguments
       matplotlibCmdArgs = mempty,
       matlabCmdArgs = mempty,
@@ -87,7 +87,7 @@ defaultConfiguration =
       graphvizCmdArgs = mempty,
       bokehCmdArgs = mempty,
       plotsjlCmdArgs = mempty,
-      plantumlCmdArgs = mempty,
+      plantumlCmdArgs = "-jar plantuml.jar",
       -- Extras
       matplotlibTightBBox = False,
       matplotlibTransparent = False

--- a/src/Text/Pandoc/Filter/Plot/Monad.hs
+++ b/src/Text/Pandoc/Filter/Plot/Monad.hs
@@ -290,6 +290,7 @@ executable tk =
     exeSelector Graphviz = asksConfig graphvizExe
     exeSelector Bokeh = asksConfig bokehExe
     exeSelector Plotsjl = asksConfig plotsjlExe
+    exeSelector PlantUML = asksConfig plantumlExe
 
 -- | The @Configuration@ type holds the default values to use
 -- when running pandoc-plot. These values can be overridden in code blocks.
@@ -354,6 +355,8 @@ data Configuration = Configuration
     bokehPreamble :: !Script,
     -- | The default preamble script for the Julia/Plots.jl toolkit.
     plotsjlPreamble :: !Script,
+    -- | The default preamble script for the PlantUML toolkit.
+    plantumlPreamble :: !Script,
     -- | The executable to use to generate figures using the matplotlib toolkit.
     matplotlibExe :: !FilePath,
     -- | The executable to use to generate figures using the MATLAB toolkit.
@@ -376,6 +379,8 @@ data Configuration = Configuration
     bokehExe :: !FilePath,
     -- | The executable to use to generate figures using the Julia/Plots.jl toolkit.
     plotsjlExe :: !FilePath,
+    -- | The executable to use to generate figures using the PlantUML toolkit.
+    plantumlExe :: !FilePath,
     -- | Command-line arguments to pass to the Python interpreter for the Matplotlib toolkit
     matplotlibCmdArgs :: !Text,
     -- | Command-line arguments to pass to the interpreter for the MATLAB toolkit.
@@ -398,6 +403,8 @@ data Configuration = Configuration
     bokehCmdArgs :: !Text,
     -- | Command-line arguments to pass to the interpreter for the Julia/Plots.jl toolkit.
     plotsjlCmdArgs :: !Text,
+    -- | Command-line arguments to pass to the interpreter for the plantUML toolkit.
+    plantumlCmdArgs :: !Text,
     -- | Whether or not to make Matplotlib figures tight by default.
     matplotlibTightBBox :: !Bool,
     -- | Whether or not to make Matplotlib figures transparent by default.

--- a/src/Text/Pandoc/Filter/Plot/Monad/Types.hs
+++ b/src/Text/Pandoc/Filter/Plot/Monad/Types.hs
@@ -58,6 +58,7 @@ data Toolkit
   | Graphviz
   | Bokeh
   | Plotsjl
+  | PlantUML
   deriving (Bounded, Eq, Enum, Generic, Ord)
 
 -- | This instance should only be used to display toolkit names
@@ -73,6 +74,7 @@ instance Show Toolkit where
   show Graphviz = "graphviz"
   show Bokeh = "Python/Bokeh"
   show Plotsjl = "Julia/Plots.jl"
+  show PlantUML = "PlantUML"
 
 -- | Class name which will trigger the filter
 cls :: Toolkit -> Text
@@ -87,6 +89,7 @@ cls GNUPlot = "gnuplot"
 cls Graphviz = "graphviz"
 cls Bokeh = "bokeh"
 cls Plotsjl = "plotsjl"
+cls PlantUML = "plantuml"
 
 -- | Executable program and directory where it can be found.
 data Executable = Executable FilePath Text

--- a/src/Text/Pandoc/Filter/Plot/Monad/Types.hs
+++ b/src/Text/Pandoc/Filter/Plot/Monad/Types.hs
@@ -251,7 +251,9 @@ data OutputSpec = OutputSpec
     -- | Path to the script to render
     oScriptPath :: FilePath,
     -- | Figure output path
-    oFigurePath :: FilePath
+    oFigurePath :: FilePath,
+    -- | Current working directory (used for PlantUML)
+    oCWD :: FilePath
   }
 
 data Renderer = Renderer

--- a/src/Text/Pandoc/Filter/Plot/Renderers.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers.hs
@@ -44,6 +44,7 @@ import Text.Pandoc.Filter.Plot.Renderers.Mathematica
 import Text.Pandoc.Filter.Plot.Renderers.Matlab
 import Text.Pandoc.Filter.Plot.Renderers.Matplotlib
 import Text.Pandoc.Filter.Plot.Renderers.Octave
+import Text.Pandoc.Filter.Plot.Renderers.PlantUML
 import Text.Pandoc.Filter.Plot.Renderers.PlotlyPython
 import Text.Pandoc.Filter.Plot.Renderers.PlotlyR
 import Text.Pandoc.Filter.Plot.Renderers.Plotsjl
@@ -80,6 +81,7 @@ renderer tk = do
     sel Graphviz = graphviz
     sel Bokeh = bokeh
     sel Plotsjl = plotsjl
+    sel PlantUML = plantuml
 
 -- | Save formats supported by this renderer.
 supportedSaveFormats :: Toolkit -> [SaveFormat]
@@ -94,6 +96,7 @@ supportedSaveFormats GNUPlot = gnuplotSupportedSaveFormats
 supportedSaveFormats Graphviz = graphvizSupportedSaveFormats
 supportedSaveFormats Bokeh = bokehSupportedSaveFormats
 supportedSaveFormats Plotsjl = plotsjlSupportedSaveFormats
+supportedSaveFormats PlantUML = plantumlSupportedSaveFormats
 
 -- | The function that maps from configuration to the preamble.
 preambleSelector :: Toolkit -> (Configuration -> Script)
@@ -108,6 +111,7 @@ preambleSelector GNUPlot = gnuplotPreamble
 preambleSelector Graphviz = graphvizPreamble
 preambleSelector Bokeh = bokehPreamble
 preambleSelector Plotsjl = plotsjlPreamble
+preambleSelector PlantUML = plantumlPreamble
 
 -- | Parse code block headers for extra attributes that are specific
 -- to this renderer. By default, no extra attributes are parsed.

--- a/src/Text/Pandoc/Filter/Plot/Renderers/PlantUML.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/PlantUML.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- |
+-- Module      : $header$
+-- Copyright   : (c) Laurent P René de Cotret, 2019 - 2021
+-- License     : GNU GPL, version 2 or above
+-- Maintainer  : laurent.decotret@outlook.com
+-- Stability   : internal
+-- Portability : portable
+--
+-- Rendering PlantUML markup
+module Text.Pandoc.Filter.Plot.Renderers.PlantUML
+  ( plantuml,
+    plantumlSupportedSaveFormats,
+  )
+where
+
+import Data.Char
+import Text.Pandoc.Filter.Plot.Renderers.Prelude
+
+plantuml :: PlotM (Maybe Renderer)
+plantuml = do
+  avail <- plantumlAvailable
+  if not avail
+    then return Nothing
+    else do
+      cmdargs <- asksConfig plantumlCmdArgs
+      mexe <- executable PlantUML
+      return $
+        mexe >>= \exe@(Executable _ exename) ->
+          return
+            Renderer
+              { rendererToolkit = PlantUML,
+                rendererExe = exe,
+                rendererCapture = plantumlCapture,
+                rendererCommand = plantumlCommand cmdargs exename,
+                rendererSupportedSaveFormats = plantumlSupportedSaveFormats,
+                rendererChecks = mempty,
+                rendererLanguage = "plantuml",
+                rendererComment = mappend "' ",
+                rendererScriptExtension = ".txt"
+              }
+
+plantumlSupportedSaveFormats :: [SaveFormat]
+plantumlSupportedSaveFormats = [PNG, PDF, SVG]
+
+plantumlCommand :: Text -> Text -> OutputSpec -> Text
+plantumlCommand cmdargs exe OutputSpec {..} =
+  let fmt = fmap toLower . show . saveFormat $ oFigureSpec
+   in [st|#{exe} #{cmdargs} -t#{fmt} -o "#{oFigurePath}" "#{oScriptPath}"|]
+
+plantumlAvailable :: PlotM Bool
+plantumlAvailable = do
+  mexe <- executable PlantUML
+  case mexe of
+    Nothing -> return False
+    Just (Executable dir exe) ->
+      withPrependedPath dir $ asks envCWD >>= flip commandSuccess [st|#{exe} -h|]
+
+-- PlantUML export is entirely based on command-line arguments
+-- so there is no need to modify the script itself.
+plantumlCapture :: FigureSpec -> FilePath -> Script
+plantumlCapture FigureSpec {..} _ = script

--- a/src/Text/Pandoc/Filter/Plot/Renderers/PlantUML.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/PlantUML.hs
@@ -65,11 +65,10 @@ plantumlAvailable = do
   mexe <- executable PlantUML
   case mexe of
     Nothing -> return False
-    Just (Executable dir exe) ->
-      withPrependedPath dir $ asks envCWD >>= flip commandSuccess [st|#{exe} -h|]
+    Just (Executable dir exe) -> do
+      cmdargs <- asksConfig plantumlCmdArgs
+      withPrependedPath dir $ asks envCWD >>= flip commandSuccess [st|#{exe} #{cmdargs} -h|]
 
--- PlantUML export is entirely based on command-line arguments
--- so there is no need to modify the script itself.
 plantumlCapture :: FigureSpec -> FilePath -> Script
 plantumlCapture FigureSpec {..} fp = 
     -- Only the filename is included in the script; we need to also pass the ABSOLUTE output directory 

--- a/src/Text/Pandoc/Filter/Plot/Scripting.hs
+++ b/src/Text/Pandoc/Filter/Plot/Scripting.hs
@@ -94,6 +94,7 @@ runTempScript spec@FigureSpec {..} = do
     CheckPassed -> do
       scriptPath <- tempScriptPath spec
       target <- figurePath spec
+      cwd <- asks envCWD
 
       let scriptWithCapture = rendererCapture renderer_ spec target
 
@@ -102,7 +103,8 @@ runTempScript spec@FigureSpec {..} = do
             OutputSpec
               { oFigureSpec = spec,
                 oScriptPath = scriptPath,
-                oFigurePath = target
+                oFigurePath = target,
+                oCWD = cwd
               }
       let command_ = rendererCommand renderer_ outputSpec
 
@@ -112,7 +114,6 @@ runTempScript spec@FigureSpec {..} = do
       withPrependedPath exedir $ do
         -- It is important that the CWD be inherited from the
         -- parent process. See #2.
-        cwd <- asks envCWD
         (ec, _) <- runCommand cwd command_
         case ec of
           ExitSuccess -> return ScriptSuccess
@@ -157,8 +158,8 @@ figureContentHash FigureSpec {..} = do
           ( dpi,
             dependenciesHash,
             extraAttrs,
-            show version -- Included version because capture
-          ) -- scripts may change between releases
+            show version -- Included version because capture scripts may change between releases
+          ) 
         )
 
 -- | Determine the path a figure should have.

--- a/tests/Common.hs
+++ b/tests/Common.hs
@@ -94,6 +94,7 @@ testFileInclusion tk =
     include Graphviz = "tests/includes/graphviz.dot"
     include Bokeh = "tests/includes/bokeh.py"
     include Plotsjl = "tests/includes/plotsjl.jl"
+    include PlantUML = "tests/includes/plantuml.txt"
 
 -------------------------------------------------------------------------------
 -- Test that the files are saved in the appropriate format
@@ -333,6 +334,7 @@ trivialContent Bokeh =
       "p.line([1,2,3,4], [5,6,7,8])"
     ]
 trivialContent Plotsjl = "using Plots; x = 1:10; y = rand(10); plot(x, y);"
+trivialContent PlantUML = "@startuml\nAlice -> Bob: test\n@enduml"
 
 addCaption :: String -> Block -> Block
 addCaption caption (CodeBlock (id', cls, attrs) script) =


### PR DESCRIPTION
This PR adds support for the [PlantUML](https://plantuml.com) toolkit. Diagrams can be generated like so:

  ````markdown

  ```{.plantuml}
  @startuml
  Bob->Alice : hello
  @enduml
  ```

  ````

This PR closes #18.