### PR TITLE
Overhauled executable handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,17 @@ jobs:
           exit 1
         fi
         pandoc-plot clean tests/issue30.md
+
+        # The idea here is to install some random package (npstreams) to
+        # check whether the plots will be rendered in the appropriate
+        # environment
+        python -m venv ./issue46
+        ./issue46/bin/python -m pip install npstreams matplotlib
+        pandoc --filter pandoc-plot -i tests/issue46.md -t native
+        if [ $(ls "plots" | wc -l) != 2 ]; then
+          exit 1
+        fi
+        pandoc-plot clean tests/issue46.md
     
     - name: Build documentation
       run: source tools/mkmanual.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 pandoc-plot uses [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## Release 1.5.2
+
+* Overhauled the way executables are handled. This fixes an issue where executables specified in documents (rather than configuration) were ignored (#46).
+
 ## Release 1.5.1
 
 * Figures with no captions (and no link to the source script), will now be shown as an image, without figure numbering (#37).

--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,1 @@
 packages: pandoc-plot.cabal
-allow-newer: all

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -9,7 +9,6 @@ module Main where
 
 import Control.Monad (join, msum, void, when)
 import Data.List (intersperse, (\\))
-import Data.Maybe (fromJust)
 import Data.Text (unpack)
 import qualified Data.Text.IO as TIO
 import Data.Version (parseVersion, showVersion)
@@ -58,15 +57,15 @@ import Text.Pandoc.Filter.Plot
     plotFilter,
   )
 import Text.Pandoc.Filter.Plot.Internal
-  ( Executable (..),
-    cleanOutputDirs,
+  ( cleanOutputDirs,
     cls,
     configurationPathMeta,
     executable,
     readDoc,
     runPlotM,
     supportedSaveFormats,
-    toolkits,
+    toolkits, 
+    pathToExe
   )
 import Text.Pandoc.JSON (toJSONFilter)
 import Text.ParserCombinators.ReadP (readP_to_S)
@@ -286,8 +285,8 @@ showAvailableToolkits mfp = do
     toolkitInfo avail conf tk = do
       putStrLn $ "Toolkit: " <> show tk
       when avail $ do
-        Executable dir exe <- fmap fromJust $ runPlotM Nothing conf $ executable tk
-        putStrLn $ "    Executable: " <> (dir </> unpack exe)
+        exe <- runPlotM Nothing conf $ executable tk
+        putStrLn $ "    Executable: " <> (pathToExe exe)
       putStrLn $ "    Code block trigger: " <> (unpack . cls $ tk)
       putStrLn $ "    Supported save formats: " <> (mconcat . intersperse ", " . fmap show $ supportedSaveFormats tk)
       putStrLn mempty

--- a/pandoc-plot.cabal
+++ b/pandoc-plot.cabal
@@ -98,7 +98,7 @@ library
         , directory          >= 1.2.7 && < 2
         , filepath           >= 1.4   && < 2
         , hashable           >= 1     && < 2
-        , pandoc             >= 2.10  && < 3
+        , pandoc             >= 2.11  && < 3
         , pandoc-types       >= 1.22  && < 1.23
         , lifted-async       >= 0.10  && < 1
         , lifted-base        >= 0.2   && < 1

--- a/pandoc-plot.cabal
+++ b/pandoc-plot.cabal
@@ -148,7 +148,6 @@ test-suite tests
                    , containers
                    , directory
                    , filepath
-                   , hspec
                    , hspec-expectations
                    , pandoc-types         >= 1.20 && <= 2
                    , pandoc-plot

--- a/pandoc-plot.cabal
+++ b/pandoc-plot.cabal
@@ -1,6 +1,6 @@
 cabal-version:  2.2
 name:           pandoc-plot
-version:        1.5.1
+version:        1.5.2
 synopsis:       A Pandoc filter to include figures generated from code blocks using your plotting toolkit of choice.
 description:    A Pandoc filter to include figures generated from code blocks. 
                 Keep the document and code in the same location. Output is 
@@ -14,7 +14,11 @@ maintainer:     Laurent P. René de Cotret
 license:        GPL-2.0-or-later
 license-file:   LICENSE
 build-type:     Simple
-tested-with:    GHC == 8.10.4, GHC == 9.0.1
+tested-with:    GHC == 8.10.4, 
+                GHC == 9.0.1, 
+                GHC == 9.0.1, 
+                GHC == 9.2.1, 
+                GHC == 9.2.2
 extra-source-files:
     CHANGELOG.md
     LICENSE

--- a/src/Text/Pandoc/Filter/Plot/Monad.hs
+++ b/src/Text/Pandoc/Filter/Plot/Monad.hs
@@ -74,7 +74,6 @@ import Control.Monad.State.Strict
     evalStateT,
   )
 import Data.ByteString.Lazy (toStrict)
-import Data.Functor ((<&>))
 import Data.Hashable (hash)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
@@ -84,7 +83,6 @@ import Data.Text.Encoding (decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
 import System.Directory
   ( doesFileExist,
-    findExecutable,
     getCurrentDirectory,
     getModificationTime,
   )
@@ -269,12 +267,8 @@ fileHash path = do
         else err (mconcat ["Dependency ", pack fp, " does not exist."]) >> return 0
 
 -- | Find an executable.
-executable :: Toolkit -> PlotM (Maybe Executable)
-executable tk =
-  exeSelector tk
-    >>= \name ->
-      liftIO $
-        findExecutable name <&> fmap exeFromPath
+executable :: Toolkit -> PlotM Executable
+executable tk = exeSelector tk >>= return . exeFromPath
   where
     exeSelector Matplotlib = asksConfig matplotlibExe
     exeSelector PlotlyPython = asksConfig plotlyPythonExe

--- a/src/Text/Pandoc/Filter/Plot/Monad/Types.hs
+++ b/src/Text/Pandoc/Filter/Plot/Monad/Types.hs
@@ -26,6 +26,7 @@ module Text.Pandoc.Filter.Plot.Monad.Types
     inclusionKeys,
     Executable (..),
     exeFromPath,
+    pathToExe,
     -- Utilities
     isWindows,
   )
@@ -37,7 +38,7 @@ import Data.String (IsString (..))
 import Data.Text (Text, pack, unpack)
 import Data.Yaml (FromJSON(..), ToJSON (toJSON), withText)
 import GHC.Generics (Generic)
-import System.FilePath (splitFileName)
+import System.FilePath (splitFileName, (</>))
 import System.Info (os)
 import Text.Pandoc.Definition (Attr)
 
@@ -101,6 +102,9 @@ exeFromPath :: FilePath -> Executable
 exeFromPath fp =
   let (dir, name) = splitFileName fp
    in Executable dir (pack name)
+
+pathToExe :: Executable -> FilePath
+pathToExe (Executable dir name) = dir </> unpack name 
 
 -- | Source context for plotting scripts
 type Script = Text
@@ -170,6 +174,8 @@ inclusionKeys = enumFromTo (minBound :: InclusionKey) maxBound
 data FigureSpec = FigureSpec
   { -- | Renderer to use for this figure.
     renderer_ :: !Renderer,
+    -- | Executable to use in rendering this figure.
+    fsExecutable :: Executable,
     -- | Figure caption.
     caption :: !Text,
     -- | Append link to source code in caption.
@@ -263,13 +269,14 @@ data OutputSpec = OutputSpec
     oScriptPath :: FilePath,
     -- | Figure output path
     oFigurePath :: FilePath,
+    -- | Executable to use during rendering
+    oExecutable :: Executable,
     -- | Current working directory
     oCWD :: FilePath
   }
 
 data Renderer = Renderer
   { rendererToolkit :: Toolkit,
-    rendererExe :: Executable,
     rendererCapture :: FigureSpec -> FilePath -> Script,
     rendererCommand :: OutputSpec -> Text,
     rendererSupportedSaveFormats :: [SaveFormat],

--- a/src/Text/Pandoc/Filter/Plot/Parse.hs
+++ b/src/Text/Pandoc/Filter/Plot/Parse.hs
@@ -70,11 +70,7 @@ parseFigureSpec block@(CodeBlock (id', classes, attrs) _) = do
     Nothing -> return NotAFigure
     Just tk -> do
       r <- renderer tk
-      case r of
-        Nothing -> do
-          err $ mconcat ["Renderer for ", tshow tk, " needed but is not installed"]
-          return $ MissingToolkit tk
-        Just r' -> figureSpec r'
+      figureSpec r
   where
     attrs' = Map.fromList attrs
     preamblePath = unpack <$> Map.lookup (tshow PreambleK) attrs'
@@ -109,7 +105,7 @@ parseFigureSpec block@(CodeBlock (id', classes, attrs) _) = do
           -- Decide between reading from file or using document content
           content <- parseContent block
           
-          defaultExe <- fromJust <$> (executable rendererToolkit)
+          defaultExe <- executable rendererToolkit
 
           let caption = Map.findWithDefault mempty (tshow CaptionK) attrs'
               fsExecutable = maybe defaultExe (exeFromPath . unpack) $ Map.lookup (tshow ExecutableK) attrs'

--- a/src/Text/Pandoc/Filter/Plot/Parse.hs
+++ b/src/Text/Pandoc/Filter/Plot/Parse.hs
@@ -108,8 +108,11 @@ parseFigureSpec block@(CodeBlock (id', classes, attrs) _) = do
 
           -- Decide between reading from file or using document content
           content <- parseContent block
+          
+          defaultExe <- fromJust <$> (executable rendererToolkit)
 
           let caption = Map.findWithDefault mempty (tshow CaptionK) attrs'
+              fsExecutable = maybe defaultExe (exeFromPath . unpack) $ Map.lookup (tshow ExecutableK) attrs'
               withSource = maybe defWithSource readBool (Map.lookup (tshow WithSourceK) attrs')
               script = mconcat $ intersperse "\n" [header, includeScript, content]
               directory = makeValid $ unpack $ Map.findWithDefault (pack $ defaultDirectory conf) (tshow DirectoryK) attrs'

--- a/src/Text/Pandoc/Filter/Plot/Renderers.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers.hs
@@ -27,16 +27,14 @@ module Text.Pandoc.Filter.Plot.Renderers
 where
 
 import Control.Concurrent.Async.Lifted (forConcurrently)
-import Control.Concurrent.MVar (putMVar, takeMVar)
 import Control.Monad.Reader (local)
-import Control.Monad.State.Strict
-  ( MonadState (get, put),
-  )
+import Data.Functor ((<&>))
 import Data.List ((\\))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, isJust)
 import Data.Text (Text, pack)
+import System.Exit (ExitCode (..))
 import Text.Pandoc.Filter.Plot.Monad
 import Text.Pandoc.Filter.Plot.Monad.Logging
   ( Logger (lVerbosity),
@@ -67,41 +65,25 @@ import Text.Pandoc.Filter.Plot.Renderers.Plotsjl
     ( plotsjl, plotsjlSupportedSaveFormats )
 import Text.Pandoc.Filter.Plot.Renderers.SageMath
     ( sagemath, sagemathSupportedSaveFormats )
+import System.Directory (findExecutable)
 
 -- | Get the renderer associated with a toolkit.
 -- If the renderer has not been used before,
 -- initialize it and store where it is. It will be re-used.
-renderer :: Toolkit -> PlotM (Maybe Renderer)
-renderer tk = do
-  PlotState varHashes varRenderers <- get
-  renderers <- liftIO $ takeMVar varRenderers
-  (r', rs') <- case M.lookup tk renderers of
-    Nothing -> do
-      debug $ mconcat ["Looking for renderer for ", pack $ show tk]
-      r' <- sel tk
-      let rs' = M.insert tk r' renderers
-      return (r', rs')
-    Just e -> do
-      debug $ mconcat ["Renderer for \"", pack $ show tk, "\" already initialized."]
-      return (e, renderers)
-  liftIO $ putMVar varRenderers rs'
-  put $ PlotState varHashes varRenderers
-  return r'
-  where
-    sel :: Toolkit -> PlotM (Maybe Renderer)
-    sel Matplotlib = matplotlib
-    sel PlotlyPython = plotlyPython
-    sel PlotlyR = plotlyR
-    sel Matlab = matlab
-    sel Mathematica = mathematica
-    sel Octave = octave
-    sel GGPlot2 = ggplot2
-    sel GNUPlot = gnuplot
-    sel Graphviz = graphviz
-    sel Bokeh = bokeh
-    sel Plotsjl = plotsjl
-    sel PlantUML = plantuml
-    sel SageMath = sagemath
+renderer :: Toolkit -> PlotM Renderer
+renderer Matplotlib = matplotlib
+renderer PlotlyPython = plotlyPython
+renderer PlotlyR = plotlyR
+renderer Matlab = matlab
+renderer Mathematica = mathematica
+renderer Octave = octave
+renderer GGPlot2 = ggplot2
+renderer GNUPlot = gnuplot
+renderer Graphviz = graphviz
+renderer Bokeh = bokeh
+renderer Plotsjl = plotsjl
+renderer PlantUML = plantuml
+renderer SageMath = sagemath
 
 -- | Save formats supported by this renderer.
 supportedSaveFormats :: Toolkit -> [SaveFormat]
@@ -157,13 +139,28 @@ unavailableToolkits conf = runPlotM Nothing conf unavailableToolkitsM
 availableToolkitsM :: PlotM [Toolkit]
 availableToolkitsM = asNonStrictAndSilent $ do
     mtks <- forConcurrently toolkits $ \tk -> do
-      available <- isJust <$> renderer tk
-      if available
+      r <- renderer tk
+      exe <- executable tk
+      a <- isAvailable exe (rendererAvailability r)
+      if a
         then return $ Just tk
         else return Nothing
     return $ catMaybes mtks
   where
     asNonStrictAndSilent = local (\(RuntimeEnv f c l d) -> RuntimeEnv f (c{strictMode = False}) (l{lVerbosity = Silent}) d)
+
+    -- | Check that the supplied command results in
+    -- an exit code of 0 (i.e. no errors)
+    commandSuccess :: Text -> PlotM Bool
+    commandSuccess s = do
+      cwd <- asks envCWD 
+      (ec, _) <- runCommand cwd s
+      debug $ mconcat ["Command ", s, " resulted in ", pack $ show ec]
+      return $ ec == ExitSuccess
+
+    isAvailable :: Executable -> AvailabilityCheck -> PlotM Bool
+    isAvailable exe (CommandSuccess f) = commandSuccess (f exe)
+    isAvailable exe (ExecutableExists) = liftIO $ findExecutable (pathToExe exe) <&> isJust
 
 -- | Monadic version of @unavailableToolkits@
 unavailableToolkitsM :: PlotM [Toolkit]

--- a/src/Text/Pandoc/Filter/Plot/Renderers/Bokeh.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/Bokeh.hs
@@ -29,15 +29,12 @@ bokeh = do
     then return Nothing
     else do
       cmdargs <- asksConfig bokehCmdArgs
-      mexe <- executable Bokeh
       return $
-        mexe >>= \exe@(Executable _ exename) ->
           return
             Renderer
               { rendererToolkit = Bokeh,
-                rendererExe = exe,
                 rendererCapture = appendCapture bokehCaptureFragment,
-                rendererCommand = bokehCommand cmdargs exename,
+                rendererCommand = bokehCommand cmdargs,
                 rendererSupportedSaveFormats = bokehSupportedSaveFormats,
                 rendererChecks = [bokehCheckIfShow],
                 rendererLanguage = "python",
@@ -48,8 +45,8 @@ bokeh = do
 bokehSupportedSaveFormats :: [SaveFormat]
 bokehSupportedSaveFormats = [PNG, SVG, HTML]
 
-bokehCommand :: Text -> Text -> OutputSpec -> Text
-bokehCommand cmdargs exe OutputSpec {..} = [st|#{exe} #{cmdargs} "#{oScriptPath}"|]
+bokehCommand :: Text -> OutputSpec -> Text
+bokehCommand cmdargs OutputSpec {..} = [st|#{pathToExe oExecutable} #{cmdargs} "#{oScriptPath}"|]
 
 bokehAvailable :: PlotM Bool
 bokehAvailable = do

--- a/src/Text/Pandoc/Filter/Plot/Renderers/Bokeh.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/Bokeh.hs
@@ -22,38 +22,27 @@ import Data.Monoid (Any (..))
 import qualified Data.Text as T
 import Text.Pandoc.Filter.Plot.Renderers.Prelude
 
-bokeh :: PlotM (Maybe Renderer)
+bokeh :: PlotM Renderer
 bokeh = do
-  avail <- bokehAvailable
-  if not avail
-    then return Nothing
-    else do
       cmdargs <- asksConfig bokehCmdArgs
       return $
-          return
-            Renderer
-              { rendererToolkit = Bokeh,
-                rendererCapture = appendCapture bokehCaptureFragment,
-                rendererCommand = bokehCommand cmdargs,
-                rendererSupportedSaveFormats = bokehSupportedSaveFormats,
-                rendererChecks = [bokehCheckIfShow],
-                rendererLanguage = "python",
-                rendererComment = mappend "# ",
-                rendererScriptExtension = ".py"
-              }
+        Renderer
+          { rendererToolkit = Bokeh,
+            rendererCapture = appendCapture bokehCaptureFragment,
+            rendererCommand = bokehCommand cmdargs,
+            rendererAvailability = CommandSuccess $ \exe -> [st|#{pathToExe exe} -c "import bokeh; import selenium"|],
+            rendererSupportedSaveFormats = bokehSupportedSaveFormats,
+            rendererChecks = [bokehCheckIfShow],
+            rendererLanguage = "python",
+            rendererComment = mappend "# ",
+            rendererScriptExtension = ".py"
+          }
 
 bokehSupportedSaveFormats :: [SaveFormat]
 bokehSupportedSaveFormats = [PNG, SVG, HTML]
 
 bokehCommand :: Text -> OutputSpec -> Text
 bokehCommand cmdargs OutputSpec {..} = [st|#{pathToExe oExecutable} #{cmdargs} "#{oScriptPath}"|]
-
-bokehAvailable :: PlotM Bool
-bokehAvailable = do
-  mexe <- executable Bokeh
-  case mexe of
-    Nothing -> return False
-    Just (Executable dir exe) -> withPrependedPath dir $ asks envCWD >>= flip commandSuccess [st|#{exe} -c "import bokeh; import selenium"|]
 
 -- | Check if `bokeh.io.show()` calls are present in the script,
 -- which would halt pandoc-plot

--- a/src/Text/Pandoc/Filter/Plot/Renderers/GGPlot2.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/GGPlot2.hs
@@ -28,15 +28,12 @@ ggplot2 = do
     then return Nothing
     else do
       cmdargs <- asksConfig ggplot2CmdArgs
-      mexe <- executable GGPlot2
       return $
-        mexe >>= \exe@(Executable _ exename) ->
           return
             Renderer
               { rendererToolkit = GGPlot2,
-                rendererExe = exe,
                 rendererCapture = ggplot2Capture,
-                rendererCommand = ggplot2Command cmdargs exename,
+                rendererCommand = ggplot2Command cmdargs,
                 rendererSupportedSaveFormats = ggplot2SupportedSaveFormats,
                 rendererChecks = mempty,
                 rendererLanguage = "r",
@@ -47,8 +44,8 @@ ggplot2 = do
 ggplot2SupportedSaveFormats :: [SaveFormat]
 ggplot2SupportedSaveFormats = [PNG, PDF, SVG, JPG, EPS, TIF]
 
-ggplot2Command :: Text -> Text -> OutputSpec -> Text
-ggplot2Command cmdargs exe OutputSpec {..} = [st|#{exe} #{cmdargs} "#{oScriptPath}"|]
+ggplot2Command :: Text -> OutputSpec -> Text
+ggplot2Command cmdargs OutputSpec {..} = [st|#{pathToExe oExecutable} #{cmdargs} "#{oScriptPath}"|]
 
 ggplot2Available :: PlotM Bool
 ggplot2Available = do

--- a/src/Text/Pandoc/Filter/Plot/Renderers/GNUPlot.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/GNUPlot.hs
@@ -27,15 +27,12 @@ gnuplot = do
     then return Nothing
     else do
       cmdargs <- asksConfig gnuplotCmdArgs
-      mexe <- executable GNUPlot
       return $
-        mexe >>= \exe@(Executable _ exename) ->
           return
             Renderer
               { rendererToolkit = GNUPlot,
-                rendererExe = exe,
                 rendererCapture = gnuplotCapture,
-                rendererCommand = gnuplotCommand cmdargs exename,
+                rendererCommand = gnuplotCommand cmdargs,
                 rendererSupportedSaveFormats = gnuplotSupportedSaveFormats,
                 rendererChecks = mempty,
                 rendererLanguage = "gnuplot",
@@ -46,8 +43,8 @@ gnuplot = do
 gnuplotSupportedSaveFormats :: [SaveFormat]
 gnuplotSupportedSaveFormats = [LaTeX, PNG, SVG, EPS, GIF, JPG, PDF]
 
-gnuplotCommand :: Text -> Text -> OutputSpec -> Text
-gnuplotCommand cmdargs exe OutputSpec {..} = [st|#{exe} #{cmdargs} -c "#{oScriptPath}"|]
+gnuplotCommand :: Text -> OutputSpec -> Text
+gnuplotCommand cmdargs OutputSpec {..} = [st|#{pathToExe oExecutable} #{cmdargs} -c "#{oScriptPath}"|]
 
 gnuplotAvailable :: PlotM Bool
 gnuplotAvailable = do

--- a/src/Text/Pandoc/Filter/Plot/Renderers/Graphviz.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/Graphviz.hs
@@ -28,15 +28,12 @@ graphviz = do
     then return Nothing
     else do
       cmdargs <- asksConfig graphvizCmdArgs
-      mexe <- executable Graphviz
       return $
-        mexe >>= \exe@(Executable _ exename) ->
           return
             Renderer
               { rendererToolkit = Graphviz,
-                rendererExe = exe,
                 rendererCapture = graphvizCapture,
-                rendererCommand = graphvizCommand cmdargs exename,
+                rendererCommand = graphvizCommand cmdargs,
                 rendererSupportedSaveFormats = graphvizSupportedSaveFormats,
                 rendererChecks = mempty,
                 rendererLanguage = "dot",
@@ -47,11 +44,11 @@ graphviz = do
 graphvizSupportedSaveFormats :: [SaveFormat]
 graphvizSupportedSaveFormats = [PNG, PDF, SVG, JPG, EPS, WEBP, GIF]
 
-graphvizCommand :: Text -> Text -> OutputSpec -> Text
-graphvizCommand cmdargs exe OutputSpec {..} =
+graphvizCommand :: Text -> OutputSpec -> Text
+graphvizCommand cmdargs OutputSpec {..} =
   let fmt = fmap toLower . show . saveFormat $ oFigureSpec
       dpi' = dpi oFigureSpec
-   in [st|#{exe} #{cmdargs} -T#{fmt} -Gdpi=#{dpi'} -o "#{oFigurePath}" "#{oScriptPath}"|]
+   in [st|#{pathToExe oExecutable} #{cmdargs} -T#{fmt} -Gdpi=#{dpi'} -o "#{oFigurePath}" "#{oScriptPath}"|]
 
 graphvizAvailable :: PlotM Bool
 graphvizAvailable = do

--- a/src/Text/Pandoc/Filter/Plot/Renderers/Graphviz.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/Graphviz.hs
@@ -21,25 +21,21 @@ where
 import Data.Char
 import Text.Pandoc.Filter.Plot.Renderers.Prelude
 
-graphviz :: PlotM (Maybe Renderer)
+graphviz :: PlotM Renderer
 graphviz = do
-  avail <- graphvizAvailable
-  if not avail
-    then return Nothing
-    else do
       cmdargs <- asksConfig graphvizCmdArgs
       return $
-          return
-            Renderer
-              { rendererToolkit = Graphviz,
-                rendererCapture = graphvizCapture,
-                rendererCommand = graphvizCommand cmdargs,
-                rendererSupportedSaveFormats = graphvizSupportedSaveFormats,
-                rendererChecks = mempty,
-                rendererLanguage = "dot",
-                rendererComment = mappend "// ",
-                rendererScriptExtension = ".dot"
-              }
+        Renderer
+          { rendererToolkit = Graphviz,
+            rendererCapture = graphvizCapture,
+            rendererCommand = graphvizCommand cmdargs,
+            rendererAvailability = CommandSuccess $ \exe -> [st|#{pathToExe exe} -?|],
+            rendererSupportedSaveFormats = graphvizSupportedSaveFormats,
+            rendererChecks = mempty,
+            rendererLanguage = "dot",
+            rendererComment = mappend "// ",
+            rendererScriptExtension = ".dot"
+          }
 
 graphvizSupportedSaveFormats :: [SaveFormat]
 graphvizSupportedSaveFormats = [PNG, PDF, SVG, JPG, EPS, WEBP, GIF]
@@ -49,14 +45,6 @@ graphvizCommand cmdargs OutputSpec {..} =
   let fmt = fmap toLower . show . saveFormat $ oFigureSpec
       dpi' = dpi oFigureSpec
    in [st|#{pathToExe oExecutable} #{cmdargs} -T#{fmt} -Gdpi=#{dpi'} -o "#{oFigurePath}" "#{oScriptPath}"|]
-
-graphvizAvailable :: PlotM Bool
-graphvizAvailable = do
-  mexe <- executable Graphviz
-  case mexe of
-    Nothing -> return False
-    Just (Executable dir exe) ->
-      withPrependedPath dir $ asks envCWD >>= flip commandSuccess [st|#{exe} -?|]
 
 -- Graphviz export is entirely based on command-line arguments
 -- so there is no need to modify the script itself.

--- a/src/Text/Pandoc/Filter/Plot/Renderers/Mathematica.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/Mathematica.hs
@@ -27,15 +27,12 @@ mathematica = do
     then return Nothing
     else do
       cmdargs <- asksConfig mathematicaCmdArgs
-      mexe <- executable Mathematica
       return $
-        mexe >>= \exe@(Executable _ exename) ->
           return
             Renderer
               { rendererToolkit = Mathematica,
-                rendererExe = exe,
                 rendererCapture = mathematicaCapture,
-                rendererCommand = mathematicaCommand cmdargs exename,
+                rendererCommand = mathematicaCommand cmdargs,
                 rendererSupportedSaveFormats = mathematicaSupportedSaveFormats,
                 rendererChecks = mempty,
                 rendererLanguage = "mathematica",
@@ -46,8 +43,8 @@ mathematica = do
 mathematicaSupportedSaveFormats :: [SaveFormat]
 mathematicaSupportedSaveFormats = [PNG, PDF, SVG, JPG, EPS, GIF, TIF]
 
-mathematicaCommand :: Text -> Text -> OutputSpec -> Text
-mathematicaCommand cmdargs exe OutputSpec {..} = [st|#{exe} #{cmdargs} -script "#{oScriptPath}"|]
+mathematicaCommand :: Text -> OutputSpec -> Text
+mathematicaCommand cmdargs OutputSpec {..} = [st|#{pathToExe oExecutable} #{cmdargs} -script "#{oScriptPath}"|]
 
 mathematicaAvailable :: PlotM Bool
 mathematicaAvailable = do

--- a/src/Text/Pandoc/Filter/Plot/Renderers/Mathematica.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/Mathematica.hs
@@ -20,39 +20,27 @@ where
 
 import Text.Pandoc.Filter.Plot.Renderers.Prelude
 
-mathematica :: PlotM (Maybe Renderer)
+mathematica :: PlotM Renderer
 mathematica = do
-  avail <- mathematicaAvailable
-  if not avail
-    then return Nothing
-    else do
       cmdargs <- asksConfig mathematicaCmdArgs
       return $
-          return
-            Renderer
-              { rendererToolkit = Mathematica,
-                rendererCapture = mathematicaCapture,
-                rendererCommand = mathematicaCommand cmdargs,
-                rendererSupportedSaveFormats = mathematicaSupportedSaveFormats,
-                rendererChecks = mempty,
-                rendererLanguage = "mathematica",
-                rendererComment = \t -> mconcat ["(*", t, "*)"],
-                rendererScriptExtension = ".m"
-              }
+        Renderer
+          { rendererToolkit = Mathematica,
+            rendererCapture = mathematicaCapture,
+            rendererCommand = mathematicaCommand cmdargs,
+            rendererAvailability = CommandSuccess $ \exe -> [st|#{pathToExe exe} -h|], -- TODO: test this
+            rendererSupportedSaveFormats = mathematicaSupportedSaveFormats,
+            rendererChecks = mempty,
+            rendererLanguage = "mathematica",
+            rendererComment = \t -> mconcat ["(*", t, "*)"],
+            rendererScriptExtension = ".m"
+          }
 
 mathematicaSupportedSaveFormats :: [SaveFormat]
 mathematicaSupportedSaveFormats = [PNG, PDF, SVG, JPG, EPS, GIF, TIF]
 
 mathematicaCommand :: Text -> OutputSpec -> Text
 mathematicaCommand cmdargs OutputSpec {..} = [st|#{pathToExe oExecutable} #{cmdargs} -script "#{oScriptPath}"|]
-
-mathematicaAvailable :: PlotM Bool
-mathematicaAvailable = do
-  mexe <- executable Mathematica
-  case mexe of
-    Nothing -> return False
-    Just (Executable dir exe) ->
-      withPrependedPath dir $ asks envCWD >>= flip commandSuccess [st|#{exe} -h|] -- TODO: test this
 
 mathematicaCapture :: FigureSpec -> FilePath -> Script
 mathematicaCapture = appendCapture mathematicaCaptureFragment

--- a/src/Text/Pandoc/Filter/Plot/Renderers/Matlab.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/Matlab.hs
@@ -28,15 +28,12 @@ matlab = do
     then return Nothing
     else do
       cmdargs <- asksConfig matlabCmdArgs
-      mexe <- executable Matlab
       return $
-        mexe >>= \exe@(Executable _ exename) ->
           return
             Renderer
               { rendererToolkit = Matlab,
-                rendererExe = exe,
                 rendererCapture = matlabCapture,
-                rendererCommand = matlabCommand cmdargs exename,
+                rendererCommand = matlabCommand cmdargs,
                 rendererSupportedSaveFormats = matlabSupportedSaveFormats,
                 rendererChecks = mempty,
                 rendererLanguage = "matlab",
@@ -47,13 +44,13 @@ matlab = do
 matlabSupportedSaveFormats :: [SaveFormat]
 matlabSupportedSaveFormats = [PNG, PDF, SVG, JPG, EPS, GIF, TIF]
 
-matlabCommand :: Text -> Text -> OutputSpec -> Text
-matlabCommand cmdargs exe OutputSpec {..} = 
+matlabCommand :: Text  -> OutputSpec -> Text
+matlabCommand cmdargs OutputSpec {..} = 
   -- The MATLAB 'run' function will switch to the directory where the script
   -- is located before executing the script. Therefore, we first save the current
   -- working directory in the variable 'pandoc_plot_cwd' so that we can use it 
   -- when exporting the figure
-  [st|#{exe} #{cmdargs} -sd '#{oCWD}' -noFigureWindows -batch "pandoc_plot_cwd=pwd; run('#{oScriptPath}')"|]
+  [st|#{pathToExe oExecutable} #{cmdargs} -sd '#{oCWD}' -noFigureWindows -batch "pandoc_plot_cwd=pwd; run('#{oScriptPath}')"|]
 
 -- On Windows at least, "matlab -help"  actually returns -1, even though the
 -- help text is shown successfully!

--- a/src/Text/Pandoc/Filter/Plot/Renderers/Matplotlib.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/Matplotlib.hs
@@ -27,25 +27,21 @@ import Data.Monoid (Any (..))
 import qualified Data.Text as T
 import Text.Pandoc.Filter.Plot.Renderers.Prelude
 
-matplotlib :: PlotM (Maybe Renderer)
+matplotlib :: PlotM Renderer
 matplotlib = do
-  avail <- matplotlibAvailable
-  if not avail
-    then return Nothing
-    else do
       cmdargs <- asksConfig matplotlibCmdArgs
       return $
-          return
-            Renderer
-              { rendererToolkit = Matplotlib,
-                rendererCapture = matplotlibCapture,
-                rendererCommand = matplotlibCommand cmdargs,
-                rendererSupportedSaveFormats = matplotlibSupportedSaveFormats,
-                rendererChecks = [matplotlibCheckIfShow],
-                rendererLanguage = "python",
-                rendererComment = mappend "# ",
-                rendererScriptExtension = ".py"
-              }
+        Renderer
+          { rendererToolkit = Matplotlib,
+            rendererCapture = matplotlibCapture,
+            rendererCommand = matplotlibCommand cmdargs,
+            rendererAvailability = CommandSuccess $ \exe -> [st|#{pathToExe exe} -c "import matplotlib"|],
+            rendererSupportedSaveFormats = matplotlibSupportedSaveFormats,
+            rendererChecks = [matplotlibCheckIfShow],
+            rendererLanguage = "python",
+            rendererComment = mappend "# ",
+            rendererScriptExtension = ".py"
+          }
 
 matplotlibSupportedSaveFormats :: [SaveFormat]
 matplotlibSupportedSaveFormats = [PNG, PDF, SVG, JPG, EPS, GIF, TIF]
@@ -68,14 +64,6 @@ plt.savefig(r"#{fname}", dpi=#{dpi}, transparent=#{transparent}, bbox_inches=#{t
     transparent_ = readBool $ M.findWithDefault "False" "transparent" attrs
     tightBox = if tight_ then ("'tight'" :: Text) else ("None" :: Text)
     transparent = if transparent_ then ("True" :: Text) else ("False" :: Text)
-
-matplotlibAvailable :: PlotM Bool
-matplotlibAvailable = do
-  mexe <- executable Matplotlib
-  case mexe of
-    Nothing -> return False
-    Just (Executable dir exe) ->
-      withPrependedPath dir $ asks envCWD >>= flip commandSuccess [st|#{exe} -c "import matplotlib"|]
 
 -- | Check if `matplotlib.pyplot.show()` calls are present in the script,
 -- which would halt pandoc-plot

--- a/src/Text/Pandoc/Filter/Plot/Renderers/Matplotlib.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/Matplotlib.hs
@@ -34,15 +34,12 @@ matplotlib = do
     then return Nothing
     else do
       cmdargs <- asksConfig matplotlibCmdArgs
-      mexe <- executable Matplotlib
       return $
-        mexe >>= \exe@(Executable _ exename) ->
           return
             Renderer
               { rendererToolkit = Matplotlib,
-                rendererExe = exe,
                 rendererCapture = matplotlibCapture,
-                rendererCommand = matplotlibCommand cmdargs exename,
+                rendererCommand = matplotlibCommand cmdargs,
                 rendererSupportedSaveFormats = matplotlibSupportedSaveFormats,
                 rendererChecks = [matplotlibCheckIfShow],
                 rendererLanguage = "python",
@@ -53,8 +50,8 @@ matplotlib = do
 matplotlibSupportedSaveFormats :: [SaveFormat]
 matplotlibSupportedSaveFormats = [PNG, PDF, SVG, JPG, EPS, GIF, TIF]
 
-matplotlibCommand :: Text -> Text -> OutputSpec -> Text
-matplotlibCommand cmdargs exe OutputSpec {..} = [st|#{exe} #{cmdargs} "#{oScriptPath}"|]
+matplotlibCommand :: Text -> OutputSpec -> Text
+matplotlibCommand cmdargs OutputSpec {..} = [st|#{pathToExe oExecutable} #{cmdargs} "#{oScriptPath}"|]
 
 matplotlibCapture :: FigureSpec -> FilePath -> Script
 matplotlibCapture = appendCapture matplotlibCaptureFragment

--- a/src/Text/Pandoc/Filter/Plot/Renderers/Octave.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/Octave.hs
@@ -27,15 +27,12 @@ octave = do
     then return Nothing
     else do
       cmdargs <- asksConfig octaveCmdArgs
-      mexe <- executable Octave
       return $
-        mexe >>= \exe@(Executable _ exename) ->
           return
             Renderer
               { rendererToolkit = Octave,
-                rendererExe = exe,
                 rendererCapture = octaveCapture,
-                rendererCommand = octaveCommand cmdargs exename,
+                rendererCommand = octaveCommand cmdargs,
                 rendererSupportedSaveFormats = octaveSupportedSaveFormats,
                 rendererChecks = mempty,
                 rendererLanguage = "matlab",
@@ -46,8 +43,8 @@ octave = do
 octaveSupportedSaveFormats :: [SaveFormat]
 octaveSupportedSaveFormats = [PNG, PDF, SVG, JPG, EPS, GIF, TIF]
 
-octaveCommand :: Text -> Text -> OutputSpec -> Text
-octaveCommand cmdargs exe OutputSpec {..} = [st|#{exe} #{cmdargs} --no-gui --no-window-system "#{oScriptPath}"|]
+octaveCommand :: Text -> OutputSpec -> Text
+octaveCommand cmdargs OutputSpec {..} = [st|#{pathToExe oExecutable} #{cmdargs} --no-gui --no-window-system "#{oScriptPath}"|]
 
 octaveAvailable :: PlotM Bool
 octaveAvailable = do

--- a/src/Text/Pandoc/Filter/Plot/Renderers/PlantUML.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/PlantUML.hs
@@ -29,15 +29,12 @@ plantuml = do
     then return Nothing
     else do
       cmdargs <- asksConfig plantumlCmdArgs
-      mexe <- executable PlantUML
       return $
-        mexe >>= \exe@(Executable _ exename) ->
           return
             Renderer
               { rendererToolkit = PlantUML,
-                rendererExe = exe,
                 rendererCapture = plantumlCapture,
-                rendererCommand = plantumlCommand cmdargs exename,
+                rendererCommand = plantumlCommand cmdargs,
                 rendererSupportedSaveFormats = plantumlSupportedSaveFormats,
                 rendererChecks = mempty,
                 rendererLanguage = "plantuml",
@@ -48,14 +45,14 @@ plantuml = do
 plantumlSupportedSaveFormats :: [SaveFormat]
 plantumlSupportedSaveFormats = [PNG, PDF, SVG]
 
-plantumlCommand :: Text -> Text -> OutputSpec -> Text
-plantumlCommand cmdargs exe OutputSpec {..} =
+plantumlCommand :: Text -> OutputSpec -> Text
+plantumlCommand cmdargs OutputSpec {..} =
   let fmt = fmap toLower . show . saveFormat $ oFigureSpec
       dir = takeDirectory oFigurePath
     -- the command below works as long as the script name is the same basename
     -- as the target figure path. E.g.: script basename of pandocplot123456789.txt
     -- will result in pandocplot123456789.(extension)
-   in [st|#{exe} #{cmdargs} -t#{fmt} -output "#{oCWD </> dir}" "#{normalizePath oScriptPath}"|]
+   in [st|#{pathToExe oExecutable} #{cmdargs} -t#{fmt} -output "#{oCWD </> dir}" "#{normalizePath oScriptPath}"|]
 
 normalizePath :: String -> String
 normalizePath = map f

--- a/src/Text/Pandoc/Filter/Plot/Renderers/PlotlyPython.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/PlotlyPython.hs
@@ -27,15 +27,12 @@ plotlyPython = do
     then return Nothing
     else do
       cmdargs <- asksConfig plotlyPythonCmdArgs
-      mexe <- executable PlotlyPython
       return $
-        mexe >>= \exe@(Executable _ exename) ->
           return
             Renderer
               { rendererToolkit = PlotlyPython,
-                rendererExe = exe,
                 rendererCapture = plotlyPythonCapture,
-                rendererCommand = plotlyPythonCommand cmdargs exename,
+                rendererCommand = plotlyPythonCommand cmdargs,
                 rendererSupportedSaveFormats = plotlyPythonSupportedSaveFormats,
                 rendererChecks = mempty,
                 rendererLanguage = "python",
@@ -46,8 +43,8 @@ plotlyPython = do
 plotlyPythonSupportedSaveFormats :: [SaveFormat]
 plotlyPythonSupportedSaveFormats = [PNG, JPG, WEBP, PDF, SVG, EPS, HTML]
 
-plotlyPythonCommand :: Text -> Text -> OutputSpec -> Text
-plotlyPythonCommand cmdargs exe OutputSpec {..} = [st|#{exe} #{cmdargs} "#{oScriptPath}"|]
+plotlyPythonCommand :: Text -> OutputSpec -> Text
+plotlyPythonCommand cmdargs OutputSpec {..} = [st|#{pathToExe oExecutable} #{cmdargs} "#{oScriptPath}"|]
 
 plotlyPythonAvailable :: PlotM Bool
 plotlyPythonAvailable = do

--- a/src/Text/Pandoc/Filter/Plot/Renderers/PlotlyR.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/PlotlyR.hs
@@ -28,15 +28,12 @@ plotlyR = do
     then return Nothing
     else do
       cmdargs <- asksConfig plotlyRCmdArgs
-      mexe <- executable PlotlyR
       return $
-        mexe >>= \exe@(Executable _ exename) ->
           return
             Renderer
               { rendererToolkit = PlotlyR,
-                rendererExe = exe,
                 rendererCapture = plotlyRCapture,
-                rendererCommand = plotlyRCommand cmdargs exename,
+                rendererCommand = plotlyRCommand cmdargs,
                 rendererSupportedSaveFormats = plotlyRSupportedSaveFormats,
                 rendererChecks = mempty,
                 rendererLanguage = "r",
@@ -47,8 +44,8 @@ plotlyR = do
 plotlyRSupportedSaveFormats :: [SaveFormat]
 plotlyRSupportedSaveFormats = [PNG, PDF, SVG, JPG, EPS, HTML]
 
-plotlyRCommand :: Text -> Text -> OutputSpec -> Text
-plotlyRCommand cmdargs exe OutputSpec {..} = [st|#{exe} #{cmdargs} "#{oScriptPath}"|]
+plotlyRCommand :: Text -> OutputSpec -> Text
+plotlyRCommand cmdargs OutputSpec {..} = [st|#{pathToExe oExecutable} #{cmdargs} "#{oScriptPath}"|]
 
 plotlyRAvailable :: PlotM Bool
 plotlyRAvailable = do

--- a/src/Text/Pandoc/Filter/Plot/Renderers/Plotsjl.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/Plotsjl.hs
@@ -27,15 +27,12 @@ plotsjl = do
     then return Nothing
     else do
       cmdargs <- asksConfig plotsjlCmdArgs
-      mexe <- executable Plotsjl
       return $
-        mexe >>= \exe@(Executable _ exename) ->
           return
             Renderer
               { rendererToolkit = Plotsjl,
-                rendererExe = exe,
                 rendererCapture = plotsjlCapture,
-                rendererCommand = plotsjlCommand cmdargs exename,
+                rendererCommand = plotsjlCommand cmdargs,
                 rendererSupportedSaveFormats = plotsjlSupportedSaveFormats,
                 rendererChecks = mempty,
                 rendererLanguage = "julia",
@@ -48,8 +45,8 @@ plotsjl = do
 plotsjlSupportedSaveFormats :: [SaveFormat]
 plotsjlSupportedSaveFormats = [PNG, SVG, PDF]
 
-plotsjlCommand :: Text -> Text -> OutputSpec -> Text
-plotsjlCommand cmdargs exe OutputSpec {..} = [st|#{exe} #{cmdargs} -- "#{oScriptPath}"|]
+plotsjlCommand :: Text ->  OutputSpec -> Text
+plotsjlCommand cmdargs OutputSpec {..} = [st|#{pathToExe oExecutable} #{cmdargs} -- "#{oScriptPath}"|]
 
 plotsjlAvailable :: PlotM Bool
 plotsjlAvailable = do

--- a/src/Text/Pandoc/Filter/Plot/Renderers/Prelude.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/Prelude.hs
@@ -15,35 +15,17 @@ module Text.Pandoc.Filter.Plot.Renderers.Prelude
     Text,
     st,
     unpack,
-    commandSuccess,
-    existsOnPath,
+    findExecutable,
     appendCapture,
     toRPath,
   )
 where
 
-import Data.Functor ((<&>))
-import Data.Maybe (isJust)
 import Data.Text (Text, unpack)
 import System.Directory (findExecutable)
-import System.Exit (ExitCode (..))
 import System.FilePath (isPathSeparator)
 import Text.Pandoc.Filter.Plot.Monad
 import Text.Shakespeare.Text (st)
-
--- | Check that the supplied command results in
--- an exit code of 0 (i.e. no errors)
-commandSuccess ::
-  FilePath -> -- Directory from which to run the command
-  Text -> -- Command to run, including the executable
-  PlotM Bool
-commandSuccess fp s = do
-  (ec, _) <- runCommand fp s
-  return $ ec == ExitSuccess
-
--- | Checks that an executable is available on path, at all.
-existsOnPath :: FilePath -> IO Bool
-existsOnPath fp = findExecutable fp <&> isJust
 
 -- | A shortcut to append capture script fragments to scripts
 appendCapture ::

--- a/src/Text/Pandoc/Filter/Plot/Renderers/SageMath.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/SageMath.hs
@@ -20,25 +20,21 @@ where
 
 import Text.Pandoc.Filter.Plot.Renderers.Prelude
 
-sagemath :: PlotM (Maybe Renderer)
+sagemath :: PlotM Renderer
 sagemath = do
-  avail <- sagemathAvailable
-  if not avail
-    then return Nothing
-    else do
       cmdargs <- asksConfig sagemathCmdArgs
       return $
-          return
-            Renderer
-              { rendererToolkit = SageMath,
-                rendererCapture = sagemathCapture,
-                rendererCommand = sagemathCommand cmdargs,
-                rendererSupportedSaveFormats = sagemathSupportedSaveFormats,
-                rendererChecks = mempty,
-                rendererLanguage = "sagemath",
-                rendererComment = mappend "# ",
-                rendererScriptExtension = ".sage"
-              }
+        Renderer
+          { rendererToolkit = SageMath,
+            rendererCapture = sagemathCapture,
+            rendererCommand = sagemathCommand cmdargs,
+            rendererAvailability = CommandSuccess  $ \exe -> [st|#{pathToExe exe} -v|],
+            rendererSupportedSaveFormats = sagemathSupportedSaveFormats,
+            rendererChecks = mempty,
+            rendererLanguage = "sagemath",
+            rendererComment = mappend "# ",
+            rendererScriptExtension = ".sage"
+          }
 
 -- See here:
 -- https://doc.sagemath.org/html/en/reference/plotting/sage/plot/graphics.html#sage.plot.graphics.Graphics.save
@@ -48,18 +44,8 @@ sagemathSupportedSaveFormats = [EPS, PDF, PNG, SVG]
 sagemathCommand :: Text -> OutputSpec -> Text
 sagemathCommand cmdargs OutputSpec {..} = [st|#{pathToExe oExecutable} #{cmdargs} "#{oScriptPath}"|]
 
-sagemathAvailable :: PlotM Bool
-sagemathAvailable = do
-  mexe <- executable SageMath
-  case mexe of
-    Nothing -> return False
-    Just (Executable dir exe) -> do
-      withPrependedPath dir $ asks envCWD >>= flip commandSuccess [st|#{exe} -v|]
-
-
 sagemathCapture :: FigureSpec -> FilePath -> Script
 sagemathCapture = appendCapture sagemathCaptureFragment
-
 
 -- This capture fragment is a bit ugly because sage does not have the
 -- equivalent of matplotlib's `plt.gca()` to get a pointer to the most

--- a/src/Text/Pandoc/Filter/Plot/Renderers/SageMath.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/SageMath.hs
@@ -27,15 +27,12 @@ sagemath = do
     then return Nothing
     else do
       cmdargs <- asksConfig sagemathCmdArgs
-      mexe <- executable SageMath
       return $
-        mexe >>= \exe@(Executable _ exename) ->
           return
             Renderer
               { rendererToolkit = SageMath,
-                rendererExe = exe,
                 rendererCapture = sagemathCapture,
-                rendererCommand = sagemathCommand cmdargs exename,
+                rendererCommand = sagemathCommand cmdargs,
                 rendererSupportedSaveFormats = sagemathSupportedSaveFormats,
                 rendererChecks = mempty,
                 rendererLanguage = "sagemath",
@@ -48,8 +45,8 @@ sagemath = do
 sagemathSupportedSaveFormats :: [SaveFormat]
 sagemathSupportedSaveFormats = [EPS, PDF, PNG, SVG]
 
-sagemathCommand :: Text -> Text -> OutputSpec -> Text
-sagemathCommand cmdargs exe OutputSpec {..} = [st|#{exe} #{cmdargs} "#{oScriptPath}"|]
+sagemathCommand :: Text -> OutputSpec -> Text
+sagemathCommand cmdargs OutputSpec {..} = [st|#{pathToExe oExecutable} #{cmdargs} "#{oScriptPath}"|]
 
 sagemathAvailable :: PlotM Bool
 sagemathAvailable = do

--- a/src/Text/Pandoc/Filter/Plot/Scripting.hs
+++ b/src/Text/Pandoc/Filter/Plot/Scripting.hs
@@ -125,16 +125,12 @@ runTempScript spec@FigureSpec {..} = do
               }
       let command_ = rendererCommand renderer_ outputSpec
 
-      -- Change the PATH environment variable so the appropriate executable is
-      -- found first
-      let (Executable exedir _) = oExecutable outputSpec
-      withPrependedPath exedir $ do
-        -- It is important that the CWD be inherited from the
-        -- parent process. See #2.
-        (ec, _) <- runCommand cwd command_
-        case ec of
-          ExitSuccess -> return ScriptSuccess
-          ExitFailure code -> return $ ScriptFailure command_ code script
+      -- It is important that the CWD be inherited from the
+      -- parent process. See #2.
+      (ec, _) <- runCommand cwd command_
+      case ec of
+        ExitSuccess -> return ScriptSuccess
+        ExitFailure code -> return $ ScriptFailure command_ code script
 
 -- | Determine the temp script path from Figure specifications
 -- Note that for certain renderers, the appropriate file extension

--- a/src/Text/Pandoc/Filter/Plot/Scripting.hs
+++ b/src/Text/Pandoc/Filter/Plot/Scripting.hs
@@ -120,13 +120,14 @@ runTempScript spec@FigureSpec {..} = do
               { oFigureSpec = spec,
                 oScriptPath = scriptPath,
                 oFigurePath = target,
+                oExecutable = fsExecutable,
                 oCWD = cwd
               }
       let command_ = rendererCommand renderer_ outputSpec
 
       -- Change the PATH environment variable so the appropriate executable is
       -- found first
-      let (Executable exedir _) = rendererExe renderer_
+      let (Executable exedir _) = oExecutable outputSpec
       withPrependedPath exedir $ do
         -- It is important that the CWD be inherited from the
         -- parent process. See #2.

--- a/tests/issue46.md
+++ b/tests/issue46.md
@@ -1,0 +1,9 @@
+---
+plot-configuration: tests/fixtures/.verbose-config.yml
+---
+
+```{.matplotlib executable="./issue46/bin/python"}
+import sys
+print(f"sys.executable={sys.executable}", file=sys.stderr)
+import npstreams
+```


### PR DESCRIPTION
This PR changes the way executables are handled by `pandoc-plot`. Fixes #46  , where executables specified in documents were not being used to render figures. 