### PR TITLE
Add support for D2

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The resulting `output.html` looks like this:
   - `plotsjl`: plots using the [Julia `Plots.jl`](https://docs.juliaplots.org/latest/) package;
   - `plantuml`: diagrams using the [PlantUML](https://plantuml.com/) software suite;
   - `sageplot`: plots using the [Sage](https://www.sagemath.org/) software system.
+  - `d2`: plots using [D2](https://d2lang.com/). 
 
 To know which toolkits are useable on *your machine* (and which ones are
 not available), you can check with the `toolkits` command:

--- a/example-config.yml
+++ b/example-config.yml
@@ -142,3 +142,7 @@ sageplot:
   # preamble: sageplot.sage
   executable: sage
   command_line_arguments:
+
+d2:
+  executable: d2
+  command_line_arguments:

--- a/pandoc-plot.cabal
+++ b/pandoc-plot.cabal
@@ -79,6 +79,7 @@ library
         Text.Pandoc.Filter.Plot.Renderers.Plotsjl
         Text.Pandoc.Filter.Plot.Renderers.PlantUML
         Text.Pandoc.Filter.Plot.Renderers.SageMath
+        Text.Pandoc.Filter.Plot.Renderers.D2
         Text.Pandoc.Filter.Plot.Monad
         Text.Pandoc.Filter.Plot.Monad.Logging
         Text.Pandoc.Filter.Plot.Monad.Types

--- a/src/Text/Pandoc/Filter/Plot/Configuration.hs
+++ b/src/Text/Pandoc/Filter/Plot/Configuration.hs
@@ -64,6 +64,7 @@ defaultConfiguration =
       plotsjlPreamble = mempty,
       plantumlPreamble = mempty,
       sagemathPreamble = mempty,
+      d2Preamble = mempty,
       -- Executables
       matplotlibExe = python,
       matlabExe = "matlab",
@@ -78,6 +79,7 @@ defaultConfiguration =
       plotsjlExe = "julia",
       plantumlExe = "java",
       sagemathExe = "sage",
+      d2Exe = "d2",
       -- Command line arguments
       matplotlibCmdArgs = mempty,
       matlabCmdArgs = mempty,
@@ -92,6 +94,7 @@ defaultConfiguration =
       plotsjlCmdArgs = mempty,
       plantumlCmdArgs = "-jar plantuml.jar",
       sagemathCmdArgs = mempty,
+      d2CmdArgs = mempty,
       -- Extras
       matplotlibTightBBox = False,
       matplotlibTransparent = False
@@ -151,7 +154,8 @@ data ConfigPrecursor = ConfigPrecursor
     _bokehPrec :: !BokehPrecursor,
     _plotsjlPrec :: !PlotsjlPrecursor,
     _plantumlPrec :: !PlantUMLPrecursor,
-    _sagemathPrec :: !SageMathPrecursor
+    _sagemathPrec :: !SageMathPrecursor,
+    _d2Prec :: !D2Precursor
   }
 
 defaultConfigPrecursor :: ConfigPrecursor
@@ -178,7 +182,8 @@ defaultConfigPrecursor =
       _bokehPrec = BokehPrecursor Nothing (bokehExe defaultConfiguration) (bokehCmdArgs defaultConfiguration),
       _plotsjlPrec = PlotsjlPrecursor Nothing (plotsjlExe defaultConfiguration) (plotsjlCmdArgs defaultConfiguration),
       _plantumlPrec = PlantUMLPrecursor Nothing (plantumlExe defaultConfiguration) (plantumlCmdArgs defaultConfiguration),
-      _sagemathPrec = SageMathPrecursor Nothing (sagemathExe defaultConfiguration) (sagemathCmdArgs defaultConfiguration)
+      _sagemathPrec = SageMathPrecursor Nothing (sagemathExe defaultConfiguration) (sagemathCmdArgs defaultConfiguration),
+      _d2Prec = D2Precursor Nothing (d2Exe defaultConfiguration) (d2CmdArgs defaultConfiguration)
     }
 
 data LoggingPrecursor = LoggingPrecursor
@@ -218,6 +223,8 @@ data PlotsjlPrecursor = PlotsjlPrecursor {_plotsjlPreamble :: !(Maybe FilePath),
 data PlantUMLPrecursor = PlantUMLPrecursor {_plantumlPreamble :: !(Maybe FilePath), _plantumlExe :: !FilePath, _plantumlCmdArgs :: !Text}
 
 data SageMathPrecursor = SageMathPrecursor {_sagemathPreamble :: !(Maybe FilePath), _sagemathExe :: !FilePath, _sagemathCmdArgs :: !Text}
+
+data D2Precursor = D2Precursor {_d2Preamble :: !(Maybe FilePath), _d2Exe :: !FilePath, _d2CmdArgs :: !Text}
 
 instance FromJSON LoggingPrecursor where
   parseJSON (Object v) =
@@ -286,6 +293,10 @@ instance FromJSON SageMathPrecursor where
   parseJSON (Object v) = SageMathPrecursor <$> v .:? asKey PreambleK <*> v .:? asKey ExecutableK .!= sagemathExe defaultConfiguration <*> v .:? asKey CommandLineArgsK .!= sagemathCmdArgs defaultConfiguration
   parseJSON _ = fail $ mconcat ["Could not parse ", show SageMath, " configuration."]
 
+instance FromJSON D2Precursor where
+  parseJSON (Object v) = D2Precursor <$> v .:? asKey PreambleK <*> v .:? asKey ExecutableK .!= d2Exe defaultConfiguration <*> v .:? asKey CommandLineArgsK .!= d2CmdArgs defaultConfiguration
+  parseJSON _ = fail $ mconcat ["Could not parse ", show SageMath, " configuration."]
+
 toolkitAsKey :: Toolkit -> Key 
 toolkitAsKey = fromString . unpack . cls
 
@@ -315,6 +326,7 @@ instance FromJSON ConfigPrecursor where
     _plotsjlPrec <- v .:? toolkitAsKey Plotsjl .!= _plotsjlPrec defaultConfigPrecursor
     _plantumlPrec <- v .:? toolkitAsKey PlantUML .!= _plantumlPrec defaultConfigPrecursor
     _sagemathPrec <- v .:? toolkitAsKey SageMath .!= _sagemathPrec defaultConfigPrecursor
+    _d2Prec <- v .:? toolkitAsKey D2 .!= _d2Prec defaultConfigPrecursor
 
     return $ ConfigPrecursor {..}
   parseJSON _ = fail "Could not parse configuration."
@@ -349,6 +361,7 @@ renderConfig ConfigPrecursor {..} = do
       plotsjlExe = _plotsjlExe _plotsjlPrec
       plantumlExe = _plantumlExe _plantumlPrec
       sagemathExe = _sagemathExe _sagemathPrec
+      d2Exe = _d2Exe _d2Prec
 
       matplotlibCmdArgs = _matplotlibCmdArgs _matplotlibPrec
       matlabCmdArgs = _matlabCmdArgs _matlabPrec
@@ -363,6 +376,7 @@ renderConfig ConfigPrecursor {..} = do
       plotsjlCmdArgs = _plotsjlCmdArgs _plotsjlPrec
       plantumlCmdArgs = _plantumlCmdArgs _plantumlPrec
       sagemathCmdArgs = _sagemathCmdArgs _sagemathPrec
+      d2CmdArgs = _d2CmdArgs _d2Prec
 
   matplotlibPreamble <- readPreamble (_matplotlibPreamble _matplotlibPrec)
   matlabPreamble <- readPreamble (_matlabPreamble _matlabPrec)
@@ -377,6 +391,7 @@ renderConfig ConfigPrecursor {..} = do
   plotsjlPreamble <- readPreamble (_plotsjlPreamble _plotsjlPrec)
   plantumlPreamble <- readPreamble (_plantumlPreamble _plantumlPrec)
   sagemathPreamble <- readPreamble (_sagemathPreamble _sagemathPrec)
+  d2Preamble <- readPreamble (_d2Preamble _d2Prec)
 
   return Configuration {..}
   where

--- a/src/Text/Pandoc/Filter/Plot/Monad.hs
+++ b/src/Text/Pandoc/Filter/Plot/Monad.hs
@@ -282,6 +282,7 @@ executable tk = exeSelector tk <&> exeFromPath
     exeSelector Plotsjl = asksConfig plotsjlExe
     exeSelector PlantUML = asksConfig plantumlExe
     exeSelector SageMath = asksConfig sagemathExe
+    exeSelector D2 = asksConfig d2Exe
 
 -- | The @Configuration@ type holds the default values to use
 -- when running pandoc-plot. These values can be overridden in code blocks.
@@ -350,6 +351,8 @@ data Configuration = Configuration
     plantumlPreamble :: !Script,
     -- | The default preamble script for the SageMath toolkit.
     sagemathPreamble :: !Script,
+    -- | The default preamble script for the d2 toolkit.
+    d2Preamble :: !Script,
     -- | The executable to use to generate figures using the matplotlib toolkit.
     matplotlibExe :: !FilePath,
     -- | The executable to use to generate figures using the MATLAB toolkit.
@@ -376,6 +379,8 @@ data Configuration = Configuration
     plantumlExe :: !FilePath,
     -- | The executable to use to generate figures using SageMath.
     sagemathExe :: !FilePath,
+    -- | The executable to use to generate figures using d2.
+    d2Exe :: !FilePath,
     -- | Command-line arguments to pass to the Python interpreter for the Matplotlib toolkit
     matplotlibCmdArgs :: !Text,
     -- | Command-line arguments to pass to the interpreter for the MATLAB toolkit.
@@ -402,6 +407,8 @@ data Configuration = Configuration
     plantumlCmdArgs :: !Text,
     -- | Command-line arguments to pass to the interpreter for the SageMath toolkit.
     sagemathCmdArgs :: !Text,
+    -- | Command-line arguments to pass to the interpreter for the d2 toolkit.
+    d2CmdArgs :: !Text,
     -- | Whether or not to make Matplotlib figures tight by default.
     matplotlibTightBBox :: !Bool,
     -- | Whether or not to make Matplotlib figures transparent by default.

--- a/src/Text/Pandoc/Filter/Plot/Monad/Types.hs
+++ b/src/Text/Pandoc/Filter/Plot/Monad/Types.hs
@@ -61,6 +61,7 @@ data Toolkit
   | Plotsjl
   | PlantUML
   | SageMath
+  | D2
   deriving (Bounded, Eq, Enum, Generic, Ord)
 
 -- | This instance should only be used to display toolkit names
@@ -78,6 +79,7 @@ instance Show Toolkit where
   show Plotsjl = "Julia/Plots.jl"
   show PlantUML = "PlantUML"
   show SageMath = "SageMath"
+  show D2 = "D2"
 
 -- | Class name which will trigger the filter
 cls :: Toolkit -> Text
@@ -94,6 +96,7 @@ cls Bokeh = "bokeh"
 cls Plotsjl = "plotsjl"
 cls PlantUML = "plantuml"
 cls SageMath = "sageplot"
+cls D2 = "d2"
 
 -- | Executable program, and sometimes the directory where it can be found.
 data Executable 

--- a/src/Text/Pandoc/Filter/Plot/Renderers.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers.hs
@@ -64,6 +64,8 @@ import Text.Pandoc.Filter.Plot.Renderers.Plotsjl
     ( plotsjl, plotsjlSupportedSaveFormats )
 import Text.Pandoc.Filter.Plot.Renderers.SageMath
     ( sagemath, sagemathSupportedSaveFormats )
+import Text.Pandoc.Filter.Plot.Renderers.D2
+    ( d2, d2SupportedSaveFormats )
 import System.Directory (findExecutable)
 
 -- | Get the renderer associated with a toolkit.
@@ -83,6 +85,7 @@ renderer Bokeh = bokeh
 renderer Plotsjl = plotsjl
 renderer PlantUML = plantuml
 renderer SageMath = sagemath
+renderer D2 = d2
 
 -- | Save formats supported by this renderer.
 supportedSaveFormats :: Toolkit -> [SaveFormat]
@@ -99,6 +102,7 @@ supportedSaveFormats Bokeh = bokehSupportedSaveFormats
 supportedSaveFormats Plotsjl = plotsjlSupportedSaveFormats
 supportedSaveFormats PlantUML = plantumlSupportedSaveFormats
 supportedSaveFormats SageMath = sagemathSupportedSaveFormats
+supportedSaveFormats D2 = d2SupportedSaveFormats
 
 -- | The function that maps from configuration to the preamble.
 preambleSelector :: Toolkit -> (Configuration -> Script)
@@ -115,6 +119,7 @@ preambleSelector Bokeh = bokehPreamble
 preambleSelector Plotsjl = plotsjlPreamble
 preambleSelector PlantUML = plantumlPreamble
 preambleSelector SageMath = sagemathPreamble
+preambleSelector D2 = d2Preamble
 
 -- | Parse code block headers for extra attributes that are specific
 -- to this renderer. By default, no extra attributes are parsed.

--- a/src/Text/Pandoc/Filter/Plot/Renderers/D2.hs
+++ b/src/Text/Pandoc/Filter/Plot/Renderers/D2.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- |
+-- Module      : $header$
+-- Copyright   : (c) Sanchayan Maity, 2023 - present
+-- License     : GNU GPL, version 2 or above
+-- Maintainer  : sanchayan@sanchayanmaity.net
+-- Stability   : internal
+-- Portability : portable
+--
+-- Rendering D2 plots code blocks
+module Text.Pandoc.Filter.Plot.Renderers.D2
+  ( d2,
+    d2SupportedSaveFormats,
+  )
+where
+
+import Text.Pandoc.Filter.Plot.Renderers.Prelude
+
+d2 :: PlotM Renderer
+d2 = do
+      cmdargs <- asksConfig d2CmdArgs
+      return $
+        Renderer
+          { rendererToolkit = D2,
+            rendererCapture = d2Capture,
+            rendererCommand = d2Command cmdargs,
+            rendererAvailability = CommandSuccess $ \exe -> [st|#{pathToExe exe} -v|],
+            rendererSupportedSaveFormats = d2SupportedSaveFormats,
+            rendererChecks = mempty,
+            rendererLanguage = "d2",
+            rendererComment = mappend "# ",
+            rendererScriptExtension = ".d2"
+          }
+
+d2SupportedSaveFormats :: [SaveFormat]
+d2SupportedSaveFormats = [PNG, PDF, SVG]
+
+d2Command :: Text -> OutputSpec -> Text
+d2Command cmdargs OutputSpec {..} = [st|#{pathToExe oExecutable} #{cmdargs} "#{oScriptPath}" "#{oFigurePath}"|]
+
+-- d2 export is entirely based on command-line arguments
+-- so there is no need to modify the script itself.
+d2Capture :: FigureSpec -> FilePath -> Script
+d2Capture FigureSpec {..} _ = script

--- a/tests/Common.hs
+++ b/tests/Common.hs
@@ -119,6 +119,7 @@ testFileInclusion tk =
     include Plotsjl = "tests/includes/plotsjl.jl"
     include PlantUML = "tests/includes/plantuml.txt"
     include SageMath = "tests/includes/sagemath.sage"
+    include D2 = "tests/includes/d2-dd.d2"
 
 -------------------------------------------------------------------------------
 -- Test that the files are saved in the appropriate format
@@ -389,6 +390,7 @@ trivialContent Bokeh =
 trivialContent Plotsjl = "using Plots; x = 1:10; y = rand(10); plot(x, y);"
 trivialContent PlantUML = "@startuml\nAlice -> Bob: test\n@enduml"
 trivialContent SageMath = "G = plot(sin, 1, 10)"
+trivialContent D2 = "x -> y -> z"
 
 addCaption :: String -> Block -> Block
 addCaption caption (CodeBlock (id', cls, attrs) script) =


### PR DESCRIPTION
Adds support for D2, a modern diagram scripting language that turns text to diagrams.

See https://d2lang.com/ for documentation on D2.

Closes #57.