### PR TITLE
Remove bokeh from CI tests.

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,5 +1,4 @@
 matplotlib >= 3, <4
-bokeh >= 3, <4
 selenium >= 4, <5
 pandas >= 1, <2
 pandocfilters >= 1.5, <2


### PR DESCRIPTION
This removes Bokeh from list of installed Python packages, so CI can serve its purpose.