### PR TITLE
Install octave, Gnuplot, graphviz, PlantUML on Mac for integration testing...

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,15 @@ jobs:
         choco install --yes --no-progress plantuml
         plantuml -h
 
+    - name: Install Octave, Gnuplot, Graphviz, and PlantUML [Mac]
+      if: runner.os == 'macOS'
+      run: |
+        brew update
+        brew install octave
+        brew install gnuplot
+        brew install graphviz
+        brew install plantuml
+    
     - name: Install Plots.jl toolkit [Linux]
       # Integration tests sometimes hang on MacOS and Windows
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
This is _draft_ pull request to check whether current integration tests will work on Mac after installing prerequisites.

Independent of #61 and #62.

Please approve CI runs.