### PR TITLE
Figure embedding variants

### DIFF
--- a/docs/manual-content.md
+++ b/docs/manual-content.md
@@ -218,6 +218,11 @@ All following parameters are optional, with their default values controlled by t
 * `file` is a path to a file from which to read the figure content. If this parameter is used, the content of the code block is ignored. By using this parameter, you can use all the standard tooling of your plotting toolkit of choice, which is especially useful for complex figures.
 * `executable` is a path to the executable to use (e.g. `C:\\python3.exe`) or the name of the executable (e.g. `python3`).
 * `caption_format` is the text format of the caption. Possible values are exactly the same as `pandoc`'s format specification, usually `FORMAT+EXTENSION-EXTENSION`. For example, captions in Markdown with raw LaTeX would be parsed correctly provided that `caption_format=markdown+raw_tex`. See Pandoc's guide on [Specifying formats](https://pandoc.org/MANUAL.html#specifying-formats).
+* `mode` tells how to wrap a figure:
+    - `mode="floating"` is default mode: floating figure with a caption (all modes)
+    - `mode="column"`  creates minipage environment with a width of a single line, for narrow figures in multi-column mode (LaTeX only)
+    - `mode="inline"`  strips the figure and caption to make the figure inline (all modes)
+    - `mode="wrapped"` uses wrapfig environment to wrap text around figure (LaTeX only)
 
 
 #### Code highlighting

--- a/src/Text/Pandoc/Filter/Plot/Embed.hs
+++ b/src/Text/Pandoc/Filter/Plot/Embed.hs
@@ -74,7 +74,7 @@ toFigure fmt spec = do
     builder = case saveFormat spec of
       HTML  -> interactiveBlock
       LaTeX -> latexInput
-      _     -> figure           
+      _     -> figure
 
 figure ::
   FigureMode ->
@@ -133,6 +133,22 @@ latexInput Inline _ fp caption' = do
         \centering
         \input{#{pack $ normalizePath $ fp}}
         |]
+latexInput ColumnFigure _ fp caption' = do
+  renderedCaption' <- writeLatex caption'
+  let renderedCaption =
+        if renderedCaption' /= ""
+          then [st|\caption{#{renderedCaption'}}|]
+          else ""
+  return $
+    RawBlock
+      "latex"
+      [st|
+    \begin{minipage}{\columnwidth}
+        \centering
+        \input{#{pack $ normalizePath $ fp}}
+        #{renderedCaption}
+    \end{minipage}
+        |]
 latexInput fm _ fp caption' = do
   renderedCaption' <- writeLatex caption'
   let renderedCaption =
@@ -172,6 +188,7 @@ interactiveBlock fm _ fp caption' = do
   --       See https://github.com/jgm/pandoc/issues/6582
   -- TODO: wrap HTML figures with <img src="..." align="left"> without <div/>
   --       https://www.uvm.edu/~bnelson/computer/html/wrappingtextaroundimages.html
+  -- TODO: single-column HTML figures without <div/>.
   htmlpage <- liftIO $ T.readFile fp
   renderedCaption <- writeHtml caption'
   return $

--- a/src/Text/Pandoc/Filter/Plot/Monad/Types.hs
+++ b/src/Text/Pandoc/Filter/Plot/Monad/Types.hs
@@ -220,6 +220,8 @@ data FigureMode
   FloatingFigure
   | -- | Wrap figure in text
   WrappedFigure
+  | -- | Single-column figure for multi-column mode
+  ColumnFigure
   | -- | Inline image, no float, no caption
   Inline
   deriving (Eq, Ord, Show, Enum, Bounded, Generic)
@@ -228,6 +230,7 @@ instance IsString FigureMode where
   fromString (fmap toLower -> s)
     | s `elem` ["float",  "floating", "figure", "fig"           ] = FloatingFigure
     | s `elem` ["wrap",   "wrapped",  "wrapfig", "wrappedfigure"] = WrappedFigure
+    | s `elem` ["col",    "column",   "halfwidth"               ] = ColumnFigure 
     | s `elem` ["inline", "nofigure"                            ] = Inline
     | otherwise =
         errorWithoutStackTrace $

--- a/src/Text/Pandoc/Filter/Plot/Parse.hs
+++ b/src/Text/Pandoc/Filter/Plot/Parse.hs
@@ -116,6 +116,7 @@ parseFigureSpec block@(CodeBlock (id', classes, attrs) _) = do
               dpi = maybe defDPI (read . unpack) (Map.lookup (tshow DpiK) attrs')
               extraAttrs = Map.toList extraAttrs'
               blockAttrs = (id', filter (/= cls toolkit) classes, filteredAttrs)
+              figureMode = maybe FloatingFigure (fromString . unpack) $ Map.lookup (tshow ModeK) attrs'
 
           let blockDependencies = parseFileDependencies $ fromMaybe mempty $ Map.lookup (tshow DependenciesK) attrs'
               dependencies = defaultDependencies conf <> blockDependencies


### PR DESCRIPTION
I have added `mode="..."` parameter per figure block:

* `mode="floating"` is default mode as before
* `mode="column"` creates `minipage` environment with a width of a single line, for narrow figures in multi-column mode (LaTeX only)
* `mode="inline"` strips the figure and caption to make the figure inline (all modes)
* `mode="wrapped"` uses `wrapfig` environment to wrap text around figure (LaTeX only)